### PR TITLE
Add an option to render the backgrounds or not

### DIFF
--- a/src/routes/webshot.router.js
+++ b/src/routes/webshot.router.js
@@ -62,7 +62,9 @@ class WebshotRouter {
       await page.goto(ctx.query.url, gotoOptions);
       if (delay) await page.waitFor(delay);
       if (ctx.query.mediatype) await page.emulateMedia(ctx.query.mediatype);
-      await page.pdf({ path: filePath, format: 'A4' });
+      const printBackground = !!(ctx.query.backgrounds && ctx.query.backgrounds === 'true');
+      const pdfOptions = { path: filePath, format: 'A4', printBackground };
+      await page.pdf(pdfOptions);
 
       browser.close();
 


### PR DESCRIPTION
## Overview

This PR adds a new query parameter `backgrounds` which accepts a boolean. If set to `true`, puppeteer will then render the backgrounds (images and colours). This is useful for, for example, legends of maps where the categories are background colours.

## Testing instructions

1. Run the local server
2. In your browser, go to: http://localhost:5000/webshot?filename=without-backgrounds&url=https://www.wikipedia.org
3. In your browser, go to: http://localhost:5000/webshot?filename=with-backgrounds&backgrounds=true&url=https://www.wikipedia.org
4. Compare the two files `without-backgrounds-XXX.pdf` and `with-backgrounds-XXX.pdf`. The first one should have icons invisible in the second.